### PR TITLE
midi1: Add the ability to specify iJack

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -16,11 +16,11 @@ jobs:
       max-parallel: 5
       matrix:
         python-version:
-        - '3.8'
         - '3.9'
         - '3.10'
         - '3.11'
         - '3.12'
+        - '3.13'
 
     name: test (${{ matrix.python-version }})
     steps:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ sphinx_rtd_theme==2.0.0
 sphinxcontrib-apidoc
 readthedocs-sphinx-search==0.3.2
 recommonmark==0.7.1
-jinja2==3.1.4
+jinja2==3.1.6
 
 # needed for sphinxcontrib-apidoc to do its thing
 usb_protocol @ git+https://github.com/greatscottgadgets/python-usb-protocol.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "usb-protocol"
 description = "Python library providing utilities, data structures, constants, parsers, and tools for working with the USB protocol."
 license = { text = "BSD" }
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     {name = "Great Scott Gadgets", email = "dev@greatscottgadgets.com"},
 ]
@@ -15,11 +15,11 @@ authors = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Natural Language :: English",

--- a/usb_protocol/emitters/descriptors/microsoft10.py
+++ b/usb_protocol/emitters/descriptors/microsoft10.py
@@ -64,7 +64,7 @@ class ExtendedPropertiesDescriptorEmitter(ComplexDescriptorEmitter):
             with d.Property() as p:
                 p.dwPropertyDataType = RegistryTypes.REG_EXPAND_SZ
                 p.PropertyName       = "Icons"
-                p.PropertyData       = "%SystemRoot%\system32\shell32.dll,-233"
+                p.PropertyData       = "%SystemRoot%\\system32\\shell32.dll,-233"
 
         This adds the relevant descriptor, automatically.
         """
@@ -232,7 +232,7 @@ class MicrosoftOS10EmitterTests(unittest.TestCase):
             with d.Property() as p:
                 p.dwPropertyDataType = RegistryTypes.REG_EXPAND_SZ
                 p.PropertyName       = "Icons"
-                p.PropertyData       = "%SystemRoot%\system32\shell32.dll,-233"
+                p.PropertyData       = "%SystemRoot%\\system32\\shell32.dll,-233"
             with d.Property() as p:
                 p.dwPropertyDataType = RegistryTypes.REG_SZ
                 p.PropertyName       = "Label"

--- a/usb_protocol/emitters/descriptors/midi1.py
+++ b/usb_protocol/emitters/descriptors/midi1.py
@@ -28,8 +28,17 @@ class MidiOutJackDescriptorEmitter(ComplexDescriptorEmitter):
         sourceDescriptor.BaSourcePin = sourcePin
         self.add_subordinate_descriptor(sourceDescriptor)
 
+    def __setattr__(self, name, value):
+        if name == "iJack":
+            self._iJack = value
+        else:
+            return super().__setattr__(name, value)
+
     def _pre_emit(self):
-        self.add_subordinate_descriptor(MidiOutJackDescriptorFootEmitter())
+        foot = MidiOutJackDescriptorFootEmitter()
+        if hasattr(self, "_iJack"):
+            foot.iJack = self._iJack
+        self.add_subordinate_descriptor(foot)
         # Figure out the total length of our descriptor, including subordinates.
         subordinate_length = sum(len(sub) for sub in self._subordinates)
         self.bLength = subordinate_length + self.DESCRIPTOR_FORMAT.sizeof()


### PR DESCRIPTION
Hi,

`iJack` being part of the footer structure, it isn't currently possible to set its value. This hack lets the user specify their iJack value by storing it as a private object member and later using it when building the structure.